### PR TITLE
Update output and add support for multiple devops teams

### DIFF
--- a/__tests__/unit/test.ts
+++ b/__tests__/unit/test.ts
@@ -87,12 +87,19 @@ describe("Unit Tests", function () {
       expect(sendToSlackInternalSpy).toBeCalledTimes(2);
       expect(sendToSlackInternalSpy).toHaveBeenNthCalledWith(
         1,
-        "2 PRs are waiting for review. Team #1 Inbox looks clear! 🙌 2 tickets on snooze.\n- https://dev.azure.com/collection/project/_git/repository/pullrequest/41111: PR Title 1\n- https://dev.azure.com/collection/project/_git/repository/pullrequest/1234: [Prefixed] PR Title 1\n"
+          "2 PRs are waiting for review by coreUX:\n" +
+          "- https://dev.azure.com/collection/project/_git/repository/pullrequest/41111: PR Title 1\n" +
+          "- https://dev.azure.com/collection/project/_git/repository/pullrequest/1234: [Prefixed] PR Title 1\n" +
+          "Team #1 Inbox looks clear! 🙌 2 tickets on snooze."
       );
 
       expect(sendToSlackInternalSpy).toHaveBeenNthCalledWith(
         2,
-        "2 PRs are waiting for review. Inbox 1 looks clear! 🙌 2 tickets on snooze. Inbox 2 looks clear! 🙌 2 tickets on snooze.\n- https://dev.azure.com/collection/project/_git/repository/pullrequest/41111: PR Title 1\n- https://dev.azure.com/collection/project/_git/repository/pullrequest/1234: [Prefixed] PR Title 1\n"
+          "2 PRs are waiting for review by Another team:\n" +
+          "- https://dev.azure.com/collection/project/_git/repository/pullrequest/41111: PR Title 1\n" +
+          "- https://dev.azure.com/collection/project/_git/repository/pullrequest/1234: [Prefixed] PR Title 1\n" +
+          "Inbox 1 looks clear! 🙌 2 tickets on snooze.\n" +
+          "Inbox 2 looks clear! 🙌 2 tickets on snooze."
       );
     });
 
@@ -103,17 +110,12 @@ describe("Unit Tests", function () {
 
       await motivatron.doThings();
 
-      expect(sendToSlackSpy).toHaveBeenNthCalledWith(
-        1,
-        "1 PR is waiting for review (1 filtered).",
-        expect.anything(),
-        expect.anything()
+      expect(sendToSlackSpy.mock.calls[0][0][0]).toBe(
+        "1 PR is waiting for review (1 filtered) by coreUX:"
       );
-      expect(sendToSlackSpy).toHaveBeenNthCalledWith(
-        2,
-        "2 PRs are waiting for review.",
-        expect.anything(),
-        expect.anything()
+
+      expect(sendToSlackSpy.mock.calls[1][0][0]).toBe(
+        "2 PRs are waiting for review by Another team:"
       );
     });
   });

--- a/lib/devops.ts
+++ b/lib/devops.ts
@@ -61,7 +61,7 @@ export class DevOpsClient {
     return relevantPRs;
   }
 
-  filteredPullRequestsToURLList() : String[] {
+  filteredPullRequestsToURLList() : string[] {
     let pullRequests = this.filterPRs(
       this.findPRsWithNoVote(this.pullRequests)
     );

--- a/lib/devops.ts
+++ b/lib/devops.ts
@@ -61,28 +61,24 @@ export class DevOpsClient {
     return relevantPRs;
   }
 
-  filteredPullRequestsToURLList() {
+  filteredPullRequestsToURLList() : String[] {
     let pullRequests = this.filterPRs(
       this.findPRsWithNoVote(this.pullRequests)
     );
     if (!pullRequests || !Array.isArray(pullRequests)) {
-      return "";
+      return [];
     }
 
-    let result = "";
+    let result = [];
     for (let pullRequest of pullRequests) {
-      result =
-        result +
-        `- https://dev.azure.com/${this.devOpsTeam.collection}/${this.devOpsTeam.project}/_git/${this.devOpsTeam.repository}/pullrequest/${pullRequest.pullRequestId}: ${pullRequest.title}\n`;
-    }
-
-    if (result !== "") {
-      result = "\n" + result;
+      result.push(
+          `- https://dev.azure.com/${this.devOpsTeam.collection}/${this.devOpsTeam.project}/_git/${this.devOpsTeam.repository}/pullrequest/${pullRequest.pullRequestId}: ${pullRequest.title}`
+      );
     }
     return result;
   }
 
-  getTextAzureDevOps() {
+  getTextAzureDevOps(teamName: string) : string {
     let openedTodayCount = this.findPRsOpenedToday(this.pullRequests);
     let closedTodayCount = this.findPRsClosedToday(this.pullRequests);
     let noReviewPRsList: PullRequest[] = this.findPRsWithNoVote(
@@ -120,8 +116,10 @@ export class DevOpsClient {
       firstPart += ` (${filteredPRCount} filtered)`;
     }
 
+    firstPart = firstPart + ` by ${teamName}`;
+
     if (openedTodayCount === 0 && closedTodayCount === 0) {
-      firstPart += ".";
+      firstPart += ":";
     } else {
       firstPart += ", ";
     }
@@ -137,7 +135,7 @@ export class DevOpsClient {
           closedTodayCount
         )} ${this.wasWere(closedTodayCount)} closed`;
       }
-      secondPart = secondPart ? (secondPart += " today.") : secondPart;
+      secondPart = secondPart ? (secondPart += " today:") : secondPart;
     }
     return firstPart + secondPart;
   }

--- a/lib/slack.ts
+++ b/lib/slack.ts
@@ -24,16 +24,10 @@ export class SlackClient {
     };
   }
 
-  async sendToSlack(
-    devOpsPart: string,
-    intercomPart: string,
-    urls: string
-  ): Promise<void> {
-    let result = [devOpsPart, intercomPart];
-    let message = result.join(" ") + urls;
-
-    this.context.log(message);
-    return this.sendToSlackInternal(message);
+  async sendToSlack(message: string[]): Promise<void> {
+    let messageString = message.join("\n")
+    this.context.log(messageString);
+    return this.sendToSlackInternal(messageString);
   }
   async sendToSlackInternal(message: string): Promise<void> {
     let options = this.makePayload(message);

--- a/lib/slack.ts
+++ b/lib/slack.ts
@@ -11,7 +11,7 @@ export class SlackClient {
     this.team = team;
   }
 
-  makePayload(message: String): any {
+  makePayload(message: string): any {
     return {
       method: "post",
       headers: {


### PR DESCRIPTION
Adds support for multiple devops teams and updates the output:

Old output:
```
2 PRs are waiting for review. Inbox 1 looks clear! 🙌 2 tickets on snooze. Inbox 2 looks clear! 🙌 2 tickets on snooze.
- https://dev.azure.com/collection/project/_git/repository/pullrequest/41111: PR Title 1
- https://dev.azure.com/collection/project/_git/repository/pullrequest/1234: [Prefixed] PR Title 1
```
New output:
```
2 PRs are waiting for review by Another team:
- https://dev.azure.com/collection/project/_git/repository/pullrequest/41111: PR Title 1
- https://dev.azure.com/collection/project/_git/repository/pullrequest/1234: [Prefixed] PR Title 1
Inbox 1 looks clear! 🙌 2 tickets on snooze.
Inbox 2 looks clear! 🙌 2 tickets on snooze.
```